### PR TITLE
do not use shorthand for styles since it can not be overwritten

### DIFF
--- a/src/defaultStyle.js
+++ b/src/defaultStyle.js
@@ -1,7 +1,7 @@
 export default {
   userSelect: 'none',
   position: 'relative',
-  
+
   month:  {
     display: 'table',
     userSelect: 'none',
@@ -70,7 +70,10 @@ export default {
   day: {
     display: 'table-cell',
     padding: '.5rem',
-    border: '1px solid #eaecec',
+    borderTop: '1px solid #eaecec',
+    borderRight: '1px solid #eaecec',
+    borderLeft: '1px solid #eaecec',
+    borderBottom: '1px solid #eaecec',
     textAlign: 'center',
     cursor: 'pointer',
     verticalAlign: 'middle',
@@ -100,6 +103,3 @@ export default {
   },
 
 }
-
-
-  


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/10222766/18672805/d704bee6-7f49-11e6-8c1e-f01ccd68f220.png)

I think this is self-explanatory. If one want to overwrite border-left with border shorthand in place, one will get this warning.
